### PR TITLE
fix error handling

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -49,9 +49,9 @@ func (hm *HandlerMux) HandleConnect(ctx context.Context, edp Endpoint) {
 
 	for _, h := range hm.handlers {
 		go func(h Handler) {
-			defer wg.Done()
 
 			h.HandleConnect(ctx, edp)
+			wg.Done()
 		}(h)
 	}
 

--- a/rpc.go
+++ b/rpc.go
@@ -282,7 +282,10 @@ func (r *rpc) fetchRequest(ctx context.Context, pkt *codec.Packet) (*Request, bo
 			return nil, false, errors.Wrap(err, "error parsing request")
 		}
 		r.reqs[pkt.Req] = req
-
+		// TODO:
+		// buffer new requests to not mindlessly spawn goroutines
+		// and prioritize exisitng requests to unblock the connection time
+		// maybe use two maps
 		go r.root.HandleCall(ctx, req, r)
 	}
 

--- a/rpc.go
+++ b/rpc.go
@@ -3,6 +3,7 @@ package muxrpc // import "go.cryptoscope.co/muxrpc"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -431,7 +432,7 @@ type CallError struct {
 }
 
 func (e *CallError) Error() string {
-	return e.Message
+	return fmt.Sprintf("muxrpc CallError: %s - %s", e.Name, e.Message)
 }
 
 func parseError(data []byte) (*CallError, error) {
@@ -442,9 +443,10 @@ func parseError(data []byte) (*CallError, error) {
 		return nil, errors.Wrap(err, "error unmarshaling error packet")
 	}
 
-	if e.Name != "Error" {
-		return nil, errors.New(`name is not "Error"`)
-	}
+	// There are also TypeErrors and numerous other things we might get from this..
+	// if e.Name != "Error" {
+	// 	return nil, errors.Errorf(`name is not "Error" but %q`, e.Name)
+	// }
 
 	return &e, nil
 }

--- a/rwc.go
+++ b/rwc.go
@@ -67,7 +67,7 @@ func (r *srcReader) Read(data []byte) (int, error) {
 
 	v, err := r.src.Next(context.TODO())
 	if err != nil {
-		if err == (luigi.EOS{}) {
+		if luigi.IsEOS(err) {
 			return 0, io.EOF
 		}
 

--- a/stream.go
+++ b/stream.go
@@ -105,7 +105,6 @@ func (str *stream) Next(ctx context.Context) (interface{}, error) {
 	switch str.inCap {
 	case streamCapNone:
 		return nil, ErrStreamNotReadable
-
 	}
 
 	// cancellation
@@ -130,6 +129,7 @@ func (str *stream) Next(ctx context.Context) (interface{}, error) {
 	}
 
 	if pkt.Flag.Get(codec.FlagEndErr) {
+		// TODO: return error body?
 		return nil, luigi.EOS{}
 	}
 
@@ -160,7 +160,6 @@ func (str *stream) Next(ctx context.Context) (interface{}, error) {
 		}
 	} else if pkt.Flag.Get(codec.FlagString) {
 		dst = string(pkt.Body)
-
 	} else {
 		dst = []byte(pkt.Body)
 	}
@@ -257,7 +256,7 @@ func (str *stream) doCloseWithError(closeErr error) error {
 		err error
 	)
 
-	if luigi.IsEOS(closeErr) {
+	if closeErr == nil || luigi.IsEOS(errors.Cause(closeErr)) {
 		pkt = newEndOkayPacket(str.req, isStream)
 	} else {
 		pkt, err = newEndErrPacket(str.req, isStream, closeErr)


### PR DESCRIPTION
Two fixes in here:

## `parseError()` failed on TypeError and other JS-constructs

fixed by removing the check and changing the error formatting function.

## request and stream `CloseWithError` only checked for `luigi.IsEOS`

this meant that it failed for `err == nil` because it tried to construct an error packet and `panic()`ed on  calling `err.Error()`
