### PR TITLE
Improve debugging capabilities

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -167,7 +167,7 @@ func TestJSSyncString(t *testing.T) {
 
 	var fh FakeHandler
 	muxdbg, _ := initLogging(t, "packets")
-	packer := NewPacker(debug.Wrap(muxdbg, serv))
+	packer := NewPacker(debug.Wrap(muxdbg, debug.Dump(t.Name(), serv)))
 	rpc1 := Handle(packer, &fh)
 
 	ctx := context.Background()
@@ -181,7 +181,7 @@ func TestJSSyncString(t *testing.T) {
 
 	v, err = rpc1.Async(ctx, "string", Method{"version"}, "wrong", "params", 42)
 	r.Error(err, "rcp sync call")
-	r.Nil(v, "expected call result")
+	r.Nil(v, "unexpected call result")
 
 	v, err = rpc1.Async(ctx, "string", Method{"finalCall"}, 1000)
 	r.NoError(err, "rcp shutdown call")

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -18,13 +18,13 @@ along with go-muxrpc.  If not, see <http://www.gnu.org/licenses/>.
 package debug
 
 import (
-	"fmt"
+	"bytes"
 	"io"
 	"net"
 	"sync"
 
 	"github.com/go-kit/kit/log"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
 	"go.cryptoscope.co/muxrpc/codec"
@@ -78,7 +78,12 @@ func (lw *logWriter) work() (func(), chan error) {
 
 				return
 			}
-			lw.l.Log("pkt", fmt.Sprintf("%+v", pkt))
+			if pkt.Flag.Get(codec.FlagJSON) {
+
+				lw.l.Log("req", pkt.Req, "flag", pkt.Flag, "body", bytes.Replace(pkt.Body, []byte(`"`), []byte{}, -1))
+			} else {
+				lw.l.Log("req", pkt.Req, "flag", pkt.Flag, "body", pkt.Body)
+			}
 		}
 	}()
 

--- a/debug/dump.go
+++ b/debug/dump.go
@@ -1,0 +1,35 @@
+package debug
+
+import (
+	"io"
+	"net"
+	"os"
+
+	"github.com/cryptix/go/logging"
+)
+
+// Dump decodes every packet that passes through it and logs it
+func Dump(name string, rwc io.ReadWriteCloser) io.ReadWriteCloser {
+	rx, err := os.Create(name + ".rx")
+	logging.CheckFatal(err)
+	tx, err := os.Create(name + ".tx")
+	logging.CheckFatal(err)
+	return struct {
+		io.Reader
+		io.Writer
+		io.Closer
+	}{
+		Reader: io.TeeReader(rwc, rx),
+		Writer: io.MultiWriter(rwc, tx),
+		Closer: closer(func() error {
+			rx.Close()
+			tx.Close()
+			return rwc.Close()
+		}),
+	}
+
+}
+
+func WrapDump(c net.Conn) (net.Conn, error) {
+	return &wrappedConn{c, Dump(c.RemoteAddr().String(), c)}, nil
+}


### PR DESCRIPTION
### improve packet formatting in strucutred logging

use structured logging better by unpacking pkt='req:n flag:xzy
body:{foo, bar}' into req=n flag=xyz body={foo, bar}' (also removed the
quotes to remove the \\-escaping noise.

### add `Dump(name string, io.RWC) io.RWC` and matching netwrap.ConnWrapper

Added a Dump pipes the transmitted muxrpc data as is to a .rx and .tx file for further
debugging.